### PR TITLE
Added helper function userTypeService.getUserRole(user_id : string)

### DIFF
--- a/src/services/userRole.ts
+++ b/src/services/userRole.ts
@@ -23,11 +23,11 @@ const marshallOpts: marshallOptions = {
  * Returns the role of the user given the user id contained in the JWT access token
  * Should be either "instructor" or "student"
  */
-async function getUserRole(user_id: string) {
+async function getUserRole(username: string) {
   const command = new GetItemCommand({
     TableName: USER_TABLE,
     Key: marshall({
-      id: user_id
+      id: username
     }, marshallOpts)
   });
   try {
@@ -35,7 +35,7 @@ async function getUserRole(user_id: string) {
     if (output.Item) {
       return unmarshall(output.Item).userRole;
     }
-    throw new Error(`user_id=${user_id} not found`);
+    throw new Error(`username: ${username} not found`);
   } catch (err) {
     console.error(err);
     return err;


### PR DESCRIPTION
This returns a string of either "student" or "instructor" depending on the role given the `username` that is contained in the decoded JWT token. This is what a decoded access token looks like.
```
{
  sub: '0b56da68-b881-419f-ab7a-af87f2b39756',
  'cognito:groups': [ 'us-east-1_POfbbYTKF_Google' ],
  token_use: 'access',
  scope: 'aws.cognito.signin.user.admin phone openid profile email',
  auth_time: 1617403511,
  iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_POfbbYTKF',
  exp: 1617499860,
  iat: 1617413520,
  version: 2,
  jti: '86d25e63-9bb5-45b2-a90b-36a9976df7bb',
  client_id: '24sdf1brebo58s89ja0b63c51d',
  username: 'Google_114560337406279161954'
}
```

Now, here's a sample resolver that would make use of this helper functionality. 

```
export const myInstructorDataResolver = async (context: any) => {
   
   const tokenPayload = await validateToken(context.headers.Authorization) // first validate the JWT token
   const userRole = await userTypeService.getUserRole(tokenPayload.username) // then get the user role

   if (userRole == "instructor") {
     //  Successfully validated that the user is an instructor. 
     //  Write the rest of the resolver here.
   } else {
     // return error
   }
 };
```

This is accomplished by querying the DynamoDB Users table. A sample item currently looks like this:
![image](https://user-images.githubusercontent.com/26703075/113798237-aabcd780-9707-11eb-947e-0602ff0d415e.png)
