### PR TITLE
[BUGFIXES] Fixed cheating exploit that allows students to view question answers ; Fixed `getUserRole`

### DIFF
--- a/src/interfaces/role.ts
+++ b/src/interfaces/role.ts
@@ -1,0 +1,4 @@
+export enum RoleInternal {
+   Student = 'student',
+   Instructor = 'instructor'
+ }

--- a/src/schema/question.graphql
+++ b/src/schema/question.graphql
@@ -10,7 +10,7 @@ type FrQuestion implements Question {
    id: String!
    description: String!
    points: Int!
-   answer: String!
+   answer: String # nullable to prevent students from cheating
    feedback: String
 }
 
@@ -26,14 +26,14 @@ type McQuestion implements Question {
    description: String!
    points: Int!
    options: [QuestionOption!]!
-   answers: [Int!]!
+   answers: [Int!] # nullable to prevent students from cheating
    feedback: String
 }
 
 input FrQuestionInput {
    description: String!
    points: Int!
-   answer: String!
+   answer: String! 
 }
 
 input McQuestionInput {

--- a/src/schema/question.resolver.ts
+++ b/src/schema/question.resolver.ts
@@ -1,4 +1,7 @@
+import { RoleInternal } from "../interfaces/role";
+import { validateToken } from "../jws-verifer";
 import questionService from "../services/question";
+import userService from "../services/user";
 
 async function addFrQuestion(_: any, args: any, context: any, info: any) {
    const question: FrQuestionInput = args.question;
@@ -12,7 +15,10 @@ async function addMcQuestion(_: any, args: any, context: any, info: any) {
 
 async function listQuestionsByIds(_: any, args: any, context: any) {
    const questionIds: string[] = args.questionIds;
-   return questionService.listByIds(questionIds);
+   const tokenPayload = await validateToken(context.headers.Authorization);
+   const userRole = await userService.getUserRole(tokenPayload.username); // then get the user role
+
+   return questionService.listByIds(questionIds, userRole == RoleInternal.Instructor)
 }
 
 async function resolveQuestionType(question: any, context: any, info: any) {

--- a/src/schema/task.resolver.ts
+++ b/src/schema/task.resolver.ts
@@ -1,3 +1,4 @@
+import { RoleInternal } from "../interfaces/role";
 import { validateToken } from "../jws-verifer";
 import taskService from "../services/task";
 import userService from "../services/user";
@@ -5,8 +6,7 @@ import userService from "../services/user";
 async function addTask(_: any, args: any, context: any, info: any) {
    const tokenPayload = await validateToken(context.headers.Authorization);
    const userRole = await userService.getUserRole(tokenPayload.username); // then get the user role
-
-   if (userRole == Role.Instructor) {
+   if (userRole == RoleInternal.Instructor) {
       const task: TaskInput = args.task;
       return taskService.add(task);
    } else {

--- a/src/services/question.ts
+++ b/src/services/question.ts
@@ -66,7 +66,7 @@ async function listByIds(questionIds: string[], withAnswer: boolean = false): Pr
    try {
       const output = await dynamodb.batchGet(params);
       if (output.Responses) {
-         const questions = dbResponsesToQuestions(output.Responses[QUESTIONS_TABLE]);
+         const questions = dbResponsesToQuestions(output.Responses[QUESTIONS_TABLE], withAnswer);
          return questions;
       }
 

--- a/src/services/questionHelper.ts
+++ b/src/services/questionHelper.ts
@@ -43,7 +43,7 @@ export function mcQuestionInputToDBItem(question: McQuestionInput): QuestionItem
 }
 
 // convert row database item result to Question array
-export function dbResponsesToQuestions(items: any[]): Question[] {
+export function dbResponsesToQuestions(items: any[], withAnswer: boolean): Question[] {
    const questions: Question[] = items.map((item: any) => {
       const questionItem = unmarshall(item);
       const splits = questionItem.id.split("#");
@@ -54,14 +54,14 @@ export function dbResponsesToQuestions(items: any[]): Question[] {
             description: questionItem.description,
             points: questionItem.points,
             options: questionItem.options,
-            answers: questionItem.answers
+            answers: withAnswer ? questionItem.answers : undefined
          };
       } else if (type === "FR_QUESTION") {
          return <FrQuestion>{
             id: questionItem.id,
             description: questionItem.description,
             points: questionItem.points,
-            answer: questionItem.answer
+            answer: withAnswer? questionItem.answer : undefined
          };
       } else {
          throw new Error("Unknown Question Type");

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,5 +1,6 @@
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { USERS_TABLE_NAME } from "../environment";
+import { RoleInternal } from "../interfaces/role";
 import dynamodb from "./dynamodb";
 
 async function get(userId: string): Promise<User> {
@@ -19,8 +20,8 @@ async function get(userId: string): Promise<User> {
  * Returns the role of the user given the user id contained in the JWT access token
  * Should be either "instructor" or "student"
  */
-async function getUserRole(userId: string) {
-   return (await get(userId)).role;
+async function getUserRole(userId: string) : Promise<RoleInternal> {
+   return (await get(userId)).role.toString() as RoleInternal;
 }
 
 async function update(userId: string, input: UpdateUserInput) {


### PR DESCRIPTION
This PR addresses two defects.

**FLBE-50**: Can't create task due to bug with role enum
[http://platinum.cscaws.com:8080/browse/FLBE-48](url)

**FLBE-48**: Querying a multiple choice question using the task query or question query as a student gives the answer to the question (Allows cheating)
[http://platinum.cscaws.com:8080/browse/FLBE-48](url)

I accomplished the above with the following changes:

- Made the `answer` and `answers` types nullable

- Modified `dbResponsesToQuestions`  with an extra parameter, `withAnswer: boolean`, and used that extra parameter to null out the `answer` or `answers` field of the database question items depending on the type.
 
- Changed the `Questions` query to check for role and modify optional `withAnswer` parameter in `quizService.ListByIds` accordingly

- Added an internal `Role` enum type that uses lowercase `'instructor'` and `'student'` to fix the changes introduced by the automatic type generation. Changed `getUserRole` to return that new type. 

The end result is that it is impossible for students to prematurely access the answers to questions. They are only revealed when a task has been fully verified as complete and submitted. Attempting to access the parameters is allowed but will only return `null`.

Also, tasks and any other functions that access user role will now continue to work as expected. 