### PR TITLE
Fix defects for Goal and Mission API

### DIFF
--- a/src/schema/goal.graphql
+++ b/src/schema/goal.graphql
@@ -50,5 +50,5 @@ type Query {
 }
 
 type Mutation {
-   editOrCreateGoal(goal: GoalInput!): Goal! # returns the goal
+   editOrCreateGoal(goal: GoalInput!): String! # returns id of goal
 }

--- a/src/schema/goal.resolver.ts
+++ b/src/schema/goal.resolver.ts
@@ -17,7 +17,7 @@ async function editOrCreateGoal(_: any, args: any, context: any, info: any) {
     if(!("id" in goalInput)){
        goalInput.id = uid()
     }
-    return await goalService.addGoal(goalInput, username, userRole)
+    return goalService.addGoal(goalInput, username, userRole)
 }
 
 async function getGoalById(_: any, args: any, context: any, info: any) {

--- a/src/services/goal.ts
+++ b/src/services/goal.ts
@@ -9,7 +9,7 @@ import { dbItemsToQuestionAnswerItems } from "./taskSubmissionHelper";
 
 const GOAL_TABLE = GOALS_TABLE_NAME
 
-async function addGoal(goalInput: GoalInput, username: string, role: RoleInternal): Promise<Goal> {
+async function addGoal(goalInput: GoalInput, username: string, role: RoleInternal) {
     const goalItem: GoalItem = convertGoalInputToItem(goalInput, role, username);
    
     const params: PutCompositeParams = {
@@ -19,7 +19,7 @@ async function addGoal(goalInput: GoalInput, username: string, role: RoleInterna
 
     try {
         await dynamodb.putComposite(params);
-        return dbGoalItemToGoal(goalItem);
+        return goalInput.id;
      } catch (err) {
         throw err;
      }


### PR DESCRIPTION
This PR makes one change and fixes two defects

Change:

This PR makes the `editOrCreateGoal` mutation return the goal itself instead of a string. This is very helpful for frontends that want to update their local cache after calling the mutation.

Fix FLBE-53 Defect:

the `editOrCreateGoal` mutation was always setting `favorited` to false. Now it is set correctly to what is given in goalInput

Fix FLBE-54 Defect:

the Mission API was not validating auth tokens. Now every API call requires a valid auth token, and mutations also require an instructor role.