### PR TITLE
`getTaskObjectiveProgress` Schema and Implementation

### DIFF
--- a/src/__generated__/types.d.ts
+++ b/src/__generated__/types.d.ts
@@ -382,6 +382,7 @@ type Query = {
   getAllTargetProgress: Array<TargetProgress>;
   /** Instructor only: get a user's goal given the user and the goal id */
   getGoalById: Goal;
+  getTaskObjectiveProgress: Array<TaskObjectiveProgress>;
   getUser?: Maybe<User>;
   mission?: Maybe<Mission>;
   missions?: Maybe<Array<Maybe<Mission>>>;
@@ -441,6 +442,12 @@ type QueryGetAllTargetProgressArgs = {
 type QueryGetGoalByIdArgs = {
   id: Scalars['String'];
   user: Scalars['String'];
+};
+
+
+type QueryGetTaskObjectiveProgressArgs = {
+  taskId: Scalars['String'];
+  username?: Maybe<Scalars['String']>;
 };
 
 

--- a/src/objective/objectiveInterface.ts
+++ b/src/objective/objectiveInterface.ts
@@ -8,5 +8,5 @@ export type ObjectiveItem = CompositeDBItem &
 export const ObjectivePrefix = "OBJECTIVE";
 
 export function ObjectiveKey(objectiveId: string): string {
-   return `${ObjectivePrefix}#${objectiveId}`;
+   return `${ObjectivePrefix}#${objectiveId.replace(ObjectivePrefix + "#", '')}`;
 }

--- a/src/progress/progress.graphql
+++ b/src/progress/progress.graphql
@@ -76,6 +76,7 @@ type Query {
 
    getAllMissionProgress(courseId: String!, username: String) : [MissionProgress!]!
    getAllTargetProgress(courseId: String!, username: String) : [TargetProgress!]!
+   getTaskObjectiveProgress(taskId: String!, username: String) : [TaskObjectiveProgress!]!
 }
 
 type Mutation {

--- a/src/progress/progressInterface.ts
+++ b/src/progress/progressInterface.ts
@@ -6,8 +6,8 @@ export type ProgressItem = CompositeDBItem & {
    status: boolean;
 };
 
-// PK: TASK#XXXX
-// SK: OBJECTIVE#XXXX
+// PK: USER#XXXX
+// SK: OBJECTIVE#XXXXTASK#XXXX
 export type MasteryItem = CompositeDBItem & {
    username: string,
    taskId: string,
@@ -16,12 +16,12 @@ export type MasteryItem = CompositeDBItem & {
    mastery: string // maps to the mastery enum 
 }
 
-export function MasteryPK(taskId: string) : string {
-   return `TASK#${taskId.replace("TASK#", "")}`
+export function MasteryPK(username: string) : string {
+   return `USERNAME#${username}`
 }
 
-export function MasterySK(objectiveId: string) : string {
-   return `OBJECTIVE#${objectiveId.replace("OBJECTIVE#", "")}`
+export function MasterySK(objectiveId: string, taskId: string) : string {
+   return `OBJECTIVE#${objectiveId}TASK#${taskId}`
 }
 
 export function ProgressPK(userName: string, course: string): string {

--- a/src/progress/progressService.ts
+++ b/src/progress/progressService.ts
@@ -1,9 +1,10 @@
-import { MASTERY_TABLE, USER_PROGRESS_TABLE_NAME } from "../environment";
+import { COURSE_CONTENT_TABLE_NAME, MASTERY_TABLE, USER_PROGRESS_TABLE_NAME } from "../environment";
 import dynamodb, {
    PutCompositeParams,
    ScanParams,
    QueryParams,
-   DeleteParam
+   DeleteParam,
+   CompositeDBItem
 } from "../services/dynamodb";
 import * as helper from "./progressHelper";
 import { MasteryItem, ProgressPK } from "./progressInterface";
@@ -16,8 +17,9 @@ import taskService from "../services/task";
 import { generateMissionProgress, generateTargetProgress } from "./progressHelper";
 import { listTargetsByCourse } from "../services/target";
 import { listObjectiveItemsByCourse, listObjectivesByCourse } from "../objective/objectiveService";
-import { ObjectiveItem } from "../objective/objectiveInterface";
+import { ObjectiveItem, ObjectiveKey } from "../objective/objectiveInterface";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
+import { TaskKey } from "../interfaces/task";
 
 export async function addProgress(input: ProgressInput): Promise<string> {
    const courseItem = helper.progressInputToDBItem(input);
@@ -151,7 +153,6 @@ export async function getAllMissionProgressForUser(
 export async function getAllTargetProgressForUser(course: string, username: string) {
    const targets: Promise<Target[]> = listTargetsByCourse(course);
 
-   // TODO: Need to change objective item definition to return list of task ids
    const objectives: Promise<ObjectiveItem[]> = listObjectiveItemsByCourse(course);
    const userMasteryItems: Promise<MasteryItem[]> = listUserMasteryItemsByCourse(username, course);
    const targetProgress = generateTargetProgress(
@@ -164,8 +165,30 @@ export async function getAllTargetProgressForUser(course: string, username: stri
    return targetProgress;
 }
 
-function listUserMasteryItemsByTask(username: string, taskId: string): Promise<MasteryItem[]> {
-   throw new Error("Function not implemented.");
+export async function listObjectivesIdsByTask(taskId: string) : Promise<string[]> {
+   const params: QueryParams = {
+      tableName: COURSE_CONTENT_TABLE_NAME,
+      indexName: "SK-PK-index",
+      keyConditionExpression: "SK = :skVal and begins_with(PK, :pkPrefix)",
+      expressionAttributeValues: {
+         ":skVal": TaskKey(taskId),
+         ":pkPrefix": ObjectiveKey("")
+      }
+   };
+
+   try {
+      const output = await dynamodb.query(params);
+      if (output.Items) {
+         const submissions = output.Items.map(rawItem => {
+            return (<CompositeDBItem>unmarshall(rawItem)).PK;
+         });
+         return submissions
+      }
+
+      return [];
+   } catch (err) {
+      throw err;
+   }
 }
 
 async function listUserMasteryItemsByCourse(
@@ -178,6 +201,36 @@ async function listUserMasteryItemsByCourse(
       keyConditionExpression: "course = :courseVal and username = :userVal",
       expressionAttributeValues: {
          ":courseVal": course,
+         ":userVal": username
+      }
+   };
+
+   try {
+      const output = await dynamodb.query(params);
+      if (output.Items) {
+         const submissions = output.Items.map(rawItem => {
+            return <MasteryItem>unmarshall(rawItem);
+         });
+         return submissions;
+      }
+
+      return [];
+   } catch (err) {
+      throw err;
+   }
+}
+
+export async function listUserMasteryItemsByTask(
+   username: string,
+   taskId: string
+): Promise<MasteryItem[]> {
+
+   const params: QueryParams = {
+      tableName: MASTERY_TABLE,
+      indexName: "username-taskId-index",
+      keyConditionExpression: "taskId = :taskVal and username = :userVal",
+      expressionAttributeValues: {
+         ":taskVal": taskId,
          ":userVal": username
       }
    };

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -53,7 +53,7 @@ async function getTaskById(taskId: string): Promise<Task> {
 }
 
 export async function getTask(parent: any): Promise<Task> {
-   return taskService.getTaskById(parent.taskId);
+   return taskService.getTaskInfoById(parent.taskId);
 }
 
 async function listBySubMissionId(subMissionId: string): Promise<Task[]> {


### PR DESCRIPTION
## Overview
Addresses FLBE-62
`getTaskObjectiveProgress(taskId: String!, username: String) : [TaskObjectiveProgress!]!`

**taskId:** Not nullable, filters the TaskObjectiveProgress items to only relate to this task
**username:** Nullable, ignored when called by a student, where it assumes the JWT token username. 

There is a many-to-many relationship between tasks and objectives, each of which is represented by a `TaskObjectiveProgress` object. 
```
type TaskObjectiveProgress {
   task: Task!
   objective: Objective!
   mastery: Mastery!
}
```

This call will return a list of `TaskObjectiveProgress` objects where each `Task` corresponds to the provided `taskId`. Keep in mind that with GraphQL, if you do not specifically query for the `Task` no resources will be wasted retrieving it. 

## Example
A typical call will look like this:
```
query getTaskObjectiveProgress {
  getTaskObjectiveProgress(taskId: "559771cb2a7") {
    objective {
      objectiveName
    }
    mastery
  }
}
```
Which will return this: 
```
{
  "data": {
    "getTaskObjectiveProgress": [
      {
        "objective": {
          "objectiveName": "WC5"
        },
        "mastery": "NOT_GRADED"
      },
      {
        "objective": {
          "objectiveName": "TE1"
        },
        "mastery": "NOT_GRADED"
      }
    ]
  }
}
```
And is useful for UI like in cases on the right side of this mock-up: 
![image](https://user-images.githubusercontent.com/26703075/118573336-2f533a80-b737-11eb-9c9c-163757410d36.png)